### PR TITLE
Fix deprication warning

### DIFF
--- a/pynanoflann/nanoflann.py
+++ b/pynanoflann/nanoflann.py
@@ -103,7 +103,7 @@ class KDTree(NeighborsBase, KNeighborsMixin, RadiusNeighborsMixin):
             radius = self.radius
 
         dists, idxs = self.index.radius_neighbors(X, radius)
-        idxs = np.array([np.array(x) for x in idxs])
+        idxs = [np.array(x) for x in idxs]
 
         if self.metric == "l2":  # nanoflann returns squared
             dists = [np.sqrt(np.array(x)).squeeze() for x in dists]

--- a/pynanoflann/nanoflann.py
+++ b/pynanoflann/nanoflann.py
@@ -106,9 +106,9 @@ class KDTree(NeighborsBase, KNeighborsMixin, RadiusNeighborsMixin):
         idxs = np.array([np.array(x) for x in idxs])
 
         if self.metric == "l2":  # nanoflann returns squared
-            dists = np.array([np.sqrt(np.array(x)).squeeze() for x in dists])
+            dists = [np.sqrt(np.array(x)).squeeze() for x in dists]
         else:
-            dists = np.array([np.array(x).squeeze() for x in dists])
+            dists = [np.array(x).squeeze() for x in dists]
 
         if return_distance:
             return dists, idxs


### PR DESCRIPTION
Return a regular list from radius_neighbors instead of an array-of-arrays, which gets rid of the message:

`/home/rock/miniconda3/envs/tp3d/lib/python3.8/site-packages/pynanoflann/nanoflann.py:106: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray`
