### PR TITLE
Ensure consistent dtype and shape on output list

### DIFF
--- a/pynanoflann/nanoflann.py
+++ b/pynanoflann/nanoflann.py
@@ -103,12 +103,12 @@ class KDTree(NeighborsBase, KNeighborsMixin, RadiusNeighborsMixin):
             radius = self.radius
 
         dists, idxs = self.index.radius_neighbors(X, radius)
-        idxs = [np.array(x) for x in idxs]
+        idxs = [np.array(x, dtype=np.int64) for x in idxs]
 
         if self.metric == "l2":  # nanoflann returns squared
-            dists = [np.sqrt(np.array(x)).squeeze() for x in dists]
+            dists = [np.sqrt(np.array(x)) for x in dists]
         else:
-            dists = [np.array(x).squeeze() for x in dists]
+            dists = [np.array(x) for x in dists]
 
         if return_distance:
             return dists, idxs


### PR DESCRIPTION
One more quick fix.. If an idx list was empty, numpy will default it to float64 rather than an integer. Also I removed the `squeeze`, is there a reason that's there? If you want to keep it we should squeeze the idx list as well :)